### PR TITLE
add support to version the cache

### DIFF
--- a/js/app/cache.js
+++ b/js/app/cache.js
@@ -5,6 +5,36 @@ Andamio.cache = (function () {
 
     var cache;
 
+    var setBucket = function(bucket) {
+
+        if (cache) {
+            cache.setBucket(bucket);
+        }
+    };
+
+    /*
+     * we use a bucket with our current version string as name to store content in
+     *  and we store the version string as 'content_version'
+     *
+     * when then version changes we flush the old bucket and then switch to the new bucket
+     */
+    var handleCacheVersion = function(cache_version) {
+        // switch to main bucket so we can get the stored version
+        setBucket('');
+        // get version and check if it changed
+        if (cache_version != Andamio.cache.get('app_version')) {
+            // switch to old version bucket and flush
+            setBucket(Andamio.cache.get('app_version'));
+            Andamio.cache.flush();
+
+            // switch to main bucket and store current/new version
+            setBucket('');
+            Andamio.cache.set('app_version', cache_version);
+        }
+        // switch to current bucket
+        setBucket(cache_version);
+    };
+
     return {
 
         get: function (key) {
@@ -40,16 +70,13 @@ Andamio.cache = (function () {
             }
         },
 
-        setBucket: function (bucket) {
-
-            if (cache) {
-                cache.setBucket(bucket);
-            }
-        },
-
         init: function () {
 
             cache = Andamio.config.cache ? window.lscache : false;
+
+            if (cache && Andamio.config.cache_version) {
+                handleCacheVersion(Andamio.config.cache_version);
+            }
         }
     };
 })();


### PR DESCRIPTION
add support to version the cache using Andamio.config.cache_version string and lscache buckets.

Since Andamio.cache is used during the Andamio.init process there's no good way of externally doing this logic, hence I integrated it into Andamio.cache.
