### PR TITLE
only show nomorepages message when there are no more pages

### DIFF
--- a/js/app/pager.js
+++ b/js/app/pager.js
@@ -130,9 +130,6 @@ Andamio.pager = (function () {
         this.loadMoreAction.off("click").remove();
         this.spinner.remove();
 
-        // Show the message that there are no more pages
-        this.noMorePages.insertAfter(this.options.pagerWrapper);
-
         if (this.options.autoFetch) {
             this.disableAutofetch();
         }
@@ -202,6 +199,9 @@ Andamio.pager = (function () {
                 // if less children than items per page are returned, disable the pager
                 if (self.options.pagerWrapper.children().length - children < self.options.itemsPerPage) {
                     self.disable();
+
+                    // Show the message that there are no more pages
+                    self.noMorePages.insertAfter(self.options.pagerWrapper);
                 }
 
                 self.updateScroller();


### PR DESCRIPTION
.disable() can be called externally too, so in that case the message shouldn't appear.
